### PR TITLE
Improve env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ This project is a minimal Node.js/Express application demonstrating a sign up fo
 4. Start the app with `node server.js`.
 5. Visit `http://localhost:3000/signup` to register a user.
 
+The server requires a valid `DATABASE_URL` in your environment. If it's missing, the application will exit with an error message reminding you to create a `.env` file.
+
 ## Notes
 This repository only contains source files. Dependencies must be installed separately.

--- a/server.js
+++ b/server.js
@@ -6,6 +6,15 @@ const pgSession = require('connect-pg-simple')(session);
 const { Pool } = require('pg');
 require('dotenv').config();
 
+if (!process.env.DATABASE_URL) {
+  console.error('Missing DATABASE_URL in environment. Did you create a .env file?');
+  process.exit(1);
+}
+
+if (!process.env.SESSION_SECRET) {
+  console.warn('SESSION_SECRET is not set, using a default value.');
+}
+
 const app = express();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 


### PR DESCRIPTION
## Summary
- handle missing DATABASE_URL and SESSION_SECRET at startup
- clarify in README that a valid DATABASE_URL is required

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68490d3f574c8324ae9e253ab4f4237f