### PR TITLE
Add modern Tailwind admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ This project is a minimal Node.js/Express application demonstrating a sign up fo
 ## Features
 - Sign up form collects name, username, email, contact number with country, password/confirmation, profile picture (5MB limit) and address
 - Login form validates credentials from the database
-- Simple admin route lists all registered users (requires login)
+- Responsive UI built with React and Tailwind CSS
+- Bento style admin dashboard with editable user descriptions and an ad section
+- Toast notifications for sign up success and description saves
 
 ## Setup
 1. Copy `.env.sample` to `.env` and adjust the PostgreSQL connection string and session secret.
 2. Run `npm install` to install dependencies.
-3. Execute the SQL in `db.sql` on your PostgreSQL server.
+3. Execute the SQL in `db.sql` on your PostgreSQL server. This creates the `users` and `session` tables used by the app.
 4. Start the app with `node server.js`.
-5. Visit `http://localhost:3000/signup` to register a user.
+5. Visit `http://localhost:3000/signup` to register a user and then log in.
+6. After logging in, open `http://localhost:3000/admin` to manage users.
+
+If you see an error about the `session` table not existing, make sure you ran `db.sql` to create it.
+
+The server requires a valid `DATABASE_URL` in your environment. If it's missing, the application will exit with an error message reminding you to create a `.env` file.
 
 ## Notes
 This repository only contains source files. Dependencies must be installed separately.

--- a/db.sql
+++ b/db.sql
@@ -6,5 +6,18 @@ CREATE TABLE IF NOT EXISTS users (
   contact TEXT,
   password TEXT NOT NULL,
   picture TEXT,
-  address TEXT
+  address TEXT,
+  description TEXT
 );
+
+-- store sessions for express-session/connect-pg-simple
+CREATE TABLE IF NOT EXISTS "session" (
+  "sid" varchar NOT NULL COLLATE "default",
+  "sess" json NOT NULL,
+  "expire" timestamp(6) NOT NULL
+)
+WITH (OIDS=FALSE);
+
+ALTER TABLE "session" ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid") NOT DEFERRABLE INITIALLY IMMEDIATE;
+
+CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");

--- a/server.js
+++ b/server.js
@@ -6,14 +6,27 @@ const pgSession = require('connect-pg-simple')(session);
 const { Pool } = require('pg');
 require('dotenv').config();
 
+if (!process.env.DATABASE_URL) {
+  console.error('Missing DATABASE_URL in environment. Did you create a .env file?');
+  process.exit(1);
+}
+
+if (!process.env.SESSION_SECRET) {
+  console.warn('SESSION_SECRET is not set, using a default value.');
+}
+
 const app = express();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 app.use(express.static('public'));
 
 app.use(session({
-  store: new pgSession({ pool }),
+  store: new pgSession({
+    pool,
+    createTableIfMissing: true
+  }),
   secret: process.env.SESSION_SECRET || 'secret',
   resave: false,
   saveUninitialized: false
@@ -36,10 +49,10 @@ app.post('/signup', upload.single('picture'), async (req, res) => {
   }
   try {
     await pool.query(
-      'INSERT INTO users (name, username, email, contact, password, picture, address) VALUES ($1,$2,$3,$4,$5,$6,$7)',
-      [name, username, email, contact, password, req.file ? req.file.filename : null, address]
+      'INSERT INTO users (name, username, email, contact, password, picture, address, description) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)',
+      [name, username, email, contact, password, req.file ? req.file.filename : null, address, null]
     );
-    res.redirect('/login');
+    res.redirect('/login?signup=1');
   } catch (err) {
     console.error(err);
     res.status(500).send('Error creating user');
@@ -62,10 +75,27 @@ app.post('/login', async (req, res) => {
   }
 });
 
-app.get('/admin', async (req, res) => {
+app.get('/admin', (req, res) => {
   if (!req.session.userId) return res.redirect('/login');
-  const result = await pool.query('SELECT * FROM users');
-  res.send(result.rows);
+  res.sendFile(path.join(__dirname, 'views', 'admin.html'));
+});
+
+app.get('/api/users', async (req, res) => {
+  if (!req.session.userId) return res.status(401).send('Unauthorized');
+  const result = await pool.query('SELECT id, name, username, email, description FROM users');
+  res.json(result.rows);
+});
+
+app.put('/api/users/:id', async (req, res) => {
+  if (!req.session.userId) return res.status(401).send('Unauthorized');
+  const { description } = req.body;
+  try {
+    await pool.query('UPDATE users SET description=$1 WHERE id=$2', [description, req.params.id]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Error updating description');
+  }
 });
 
 const PORT = process.env.PORT || 3000;

--- a/views/admin.html
+++ b/views/admin.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+  <div id="root" class="w-full"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react-hot-toast@2/dist/index.umd.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="typescript,react">
+    const { useState, useEffect } = React;
+    const toast = window['react-hot-toast'].toast;
+
+    interface User {
+      id: number;
+      name: string;
+      username: string;
+      email: string;
+      description?: string;
+      picture?: string;
+    }
+
+    function UserCard({ user, onSave }: { user: User; onSave: (id:number, desc:string)=>void }) {
+      const [edit, setEdit] = useState(false);
+      const [desc, setDesc] = useState(user.description || '');
+      const avatar = user.picture ? `/uploads/${user.picture}` : 'https://via.placeholder.com/80';
+
+      const save = () => {
+        onSave(user.id, desc);
+        setEdit(false);
+      };
+
+      return (
+        <div className="bg-white p-4 rounded shadow flex flex-col">
+          <div className="flex items-center space-x-4">
+            <img src={avatar} alt="avatar" className="w-16 h-16 rounded-full object-cover" />
+            <div>
+              <h2 className="text-lg font-medium">{user.name}</h2>
+              <p className="text-sm text-gray-500">{user.email}</p>
+            </div>
+          </div>
+          <div className="mt-4 flex-1">
+            {edit ? (
+              <>
+                <textarea value={desc} onChange={e=>setDesc(e.target.value)} className="w-full border rounded p-2" />
+                <div className="mt-2 flex gap-2">
+                  <button onClick={save} className="px-3 py-1 bg-blue-500 text-white rounded text-sm">Save</button>
+                  <button onClick={()=>{setEdit(false);setDesc(user.description||'')}} className="px-3 py-1 bg-gray-200 rounded text-sm">Cancel</button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm mb-2 min-h-[2rem]">{user.description || 'No description'}</p>
+                <button onClick={()=>setEdit(true)} className="text-sm text-blue-600">Edit</button>
+              </>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    function AdSection() {
+      return (
+        <div className="bg-white rounded shadow p-4 flex flex-col justify-between h-full">
+          <div>
+            <h2 className="text-lg font-medium mb-2">Advertisements</h2>
+            <p className="text-sm text-gray-500">No active ads.</p>
+          </div>
+          <button className="mt-4 px-3 py-2 bg-green-500 text-white rounded text-sm">Create New Ad</button>
+        </div>
+      );
+    }
+
+    function AdminPanel() {
+      const [users, setUsers] = useState<User[]>([]);
+      useEffect(() => {
+        fetch('/api/users')
+          .then(res => res.json())
+          .then(setUsers);
+      }, []);
+
+      const saveDescription = async (id:number, description:string) => {
+        await fetch(`/api/users/${id}`, {
+          method: 'PUT',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({description})
+        });
+        toast.success('Description saved successfully!');
+        setUsers(u => u.map(user => user.id === id ? { ...user, description } : user));
+      };
+
+      return (
+        <div className="max-w-6xl mx-auto w-full">
+          <h1 className="text-2xl font-semibold mb-4">Admin Dashboard</h1>
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-4 md:col-span-2">
+              {users.map(u => (
+                <UserCard key={u.id} user={u} onSave={saveDescription} />
+              ))}
+            </div>
+            <AdSection />
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(
+      <React.Fragment>
+        <AdminPanel />
+        <react-hot-toast.Toaster position="top-right" />
+      </React.Fragment>,
+      document.getElementById('root')
+    );
+  </script>
+</body>
+</html>

--- a/views/login.html
+++ b/views/login.html
@@ -1,13 +1,56 @@
 <!DOCTYPE html>
-<html>
-<head><title>Login</title></head>
-<body>
-  <h1>Login</h1>
-  <form action="/login" method="post">
-    <label>Username:<input type="text" name="username" required></label><br>
-    <label>Password:<input type="password" name="password" required></label><br>
-    <button type="submit">Login</button>
-  </form>
-  <a href="/signup">Sign Up</a>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center">
+  <div id="root" class="w-full max-w-md"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react-hot-toast@2/dist/index.umd.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="typescript,react">
+    const { useState, useEffect } = React;
+    const toast = window['react-hot-toast'].toast;
+
+    function LoginForm() {
+      useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('signup')) {
+          toast.success('Welcome! Your account has been created successfully.', { duration: 4000 });
+        }
+      }, []);
+      return (
+        <div className="bg-white p-6 rounded shadow">
+          <h2 className="text-xl font-semibold mb-4 text-center">Sign In</h2>
+          <form action="/login" method="post" className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Username</label>
+              <input type="text" name="username" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Password</label>
+              <input type="password" name="password" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <button type="submit" className="w-full bg-blue-500 text-white py-2 rounded">Sign In</button>
+          </form>
+          <div className="text-center mt-4 text-sm">
+            Don't have an account? <a href="/signup" className="text-blue-600">Sign Up</a>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(
+      <React.Fragment>
+        <LoginForm />
+        <react-hot-toast.Toaster position="top-center" />
+      </React.Fragment>,
+      document.getElementById('root')
+    );
+  </script>
 </body>
 </html>

--- a/views/signup.html
+++ b/views/signup.html
@@ -1,27 +1,77 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sign Up</title>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <h1>Sign Up</h1>
-  <form action="/signup" method="post" enctype="multipart/form-data">
-    <label>Full Name:<input type="text" name="name" required></label><br>
-    <label>Username:<input type="text" name="username" required></label><br>
-    <label>Email:<input type="email" name="email" required></label><br>
-    <label>Contact:
-      <select name="contact">
-        <option value="+1 USA">🇺🇸 USA</option>
-        <option value="+91 India">🇮🇳 India</option>
-        <option value="+44 UK">🇬🇧 UK</option>
-      </select>
-    </label><br>
-    <label>Password:<input type="password" name="password" required></label><br>
-    <label>Confirm Password:<input type="password" name="confirmPassword" required></label><br>
-    <label>Picture:<input type="file" name="picture" accept="image/*"></label><br>
-    <label>Address:<textarea name="address"></textarea></label><br>
-    <button type="submit">Sign Up</button>
-  </form>
-  <a href="/login">Login</a>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center">
+  <div id="root" class="w-full max-w-lg"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/react-hot-toast@2/dist/index.umd.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="typescript,react">
+    const toast = window['react-hot-toast'].toast;
+
+    function SignupForm() {
+      return (
+        <div className="bg-white p-6 rounded shadow">
+          <h2 className="text-xl font-semibold mb-4 text-center">Create Account</h2>
+          <form action="/signup" method="post" encType="multipart/form-data" className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Full Name</label>
+              <input type="text" name="name" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Username</label>
+              <input type="text" name="username" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Email</label>
+              <input type="email" name="email" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Contact</label>
+              <select name="contact" className="w-full border rounded px-3 py-2">
+                <option value="+1 USA">🇺🇸 USA</option>
+                <option value="+91 India">🇮🇳 India</option>
+                <option value="+44 UK">🇬🇧 UK</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Password</label>
+              <input type="password" name="password" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Confirm Password</label>
+              <input type="password" name="confirmPassword" required className="w-full border rounded px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Picture</label>
+              <input type="file" name="picture" accept="image/*" className="w-full" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Address</label>
+              <textarea name="address" className="w-full border rounded px-3 py-2"></textarea>
+            </div>
+            <button type="submit" className="w-full bg-green-500 text-white py-2 rounded">Sign Up</button>
+          </form>
+          <div className="text-center mt-4 text-sm">
+            Already have an account? <a href="/login" className="text-blue-600">Login</a>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.render(
+      <React.Fragment>
+        <SignupForm />
+        <react-hot-toast.Toaster position="top-center" />
+      </React.Fragment>,
+      document.getElementById('root')
+    );
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use Tailwind CSS across login, signup and admin pages
- implement Bento-like admin grid in React
- show toast on signup success and description save
- update server redirect after signup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68490d3f574c8324ae9e253ab4f4237f